### PR TITLE
Init UpdatePreferenceViewController with its nib

### DIFF
--- a/src/UpdaterPreferenceViewController.m
+++ b/src/UpdaterPreferenceViewController.m
@@ -14,6 +14,12 @@
 
 @implementation UpdaterPreferenceViewController
 
+- (id)init
+{
+    self = [self initWithNibName:@"UpdaterPreferenceViewController" bundle:nil];
+    return self;
+}
+
 - (NSString *)identifier
 {
     return @"updater";


### PR DESCRIPTION
I'm not actually sure this is the right way to do this (and if it is, if this is the right place to do it). It looks as though they've fiddled with the behaviour in v10.10, which would explain why it works for you but not me (as I'm not on Yosemite).